### PR TITLE
Add Material UI ThemeProvider component

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+import { ThemeProvider as MuiThemeProvider, CssBaseline } from '@mui/material'
+import theme from '../config/theme'
+
+interface Props {
+  children: ReactNode
+}
+
+export default function ThemeProvider({ children }: Props) {
+  return (
+    <MuiThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </MuiThemeProvider>
+  )
+}

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,0 +1,18 @@
+import { createTheme } from '@mui/material/styles'
+import { amber, indigo } from '@mui/material/colors'
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: indigo[500],
+    },
+    secondary: {
+      main: amber[500],
+    },
+  },
+  typography: {
+    fontFamily: 'Roboto',
+  },
+})
+
+export default theme

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,17 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import { api } from '../services/api'
+
+export const store = configureStore({
+  reducer: {
+    [api.reducerPath]: api.reducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(api.middleware),
+})
+
+export type AppDispatch = typeof store.dispatch
+export type RootState = ReturnType<typeof store.getState>
+
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector


### PR DESCRIPTION
## Summary
- create reusable ThemeProvider wrapping MUI ThemeProvider
- add Redux store with typed hooks

## Testing
- no tests run per instructions

------
https://chatgpt.com/codex/tasks/task_e_687fd80ecc6c8332a3411cc6f466d31f