### PR TITLE
Add OAuth2 auth service

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+import { ThemeProvider as MuiThemeProvider, CssBaseline } from '@mui/material'
+import theme from '../config/theme'
+
+interface Props {
+  children: ReactNode
+}
+
+export default function ThemeProvider({ children }: Props) {
+  return (
+    <MuiThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </MuiThemeProvider>
+  )
+}

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,0 +1,18 @@
+import { createTheme } from '@mui/material/styles'
+import { amber, indigo } from '@mui/material/colors'
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: indigo[500],
+    },
+    secondary: {
+      main: amber[500],
+    },
+  },
+  typography: {
+    fontFamily: 'Roboto',
+  },
+})
+
+export default theme

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,38 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+
+export const api = createApi({
+  reducerPath: 'api',
+  baseQuery: fetchBaseQuery({
+    baseUrl: process.env.VITE_API_URL,
+  }),
+  tagTypes: ['MonthlyData', 'Analytics', 'Reports'],
+  endpoints: (builder) => ({
+    getMonthlyData: builder.query<any, void>({
+      query: () => ({ url: '/monthly-data' }),
+      providesTags: ['MonthlyData'],
+    }),
+    postMonthlyData: builder.mutation<any, any>({
+      query: (body) => ({
+        url: '/monthly-data',
+        method: 'POST',
+        body,
+      }),
+      invalidatesTags: ['MonthlyData'],
+    }),
+    getAnalytics: builder.query<any, void>({
+      query: () => ({ url: '/analytics' }),
+      providesTags: ['Analytics'],
+    }),
+    getReports: builder.query<any, void>({
+      query: () => ({ url: '/reports' }),
+      providesTags: ['Reports'],
+    }),
+  }),
+})
+
+export const {
+  useGetMonthlyDataQuery,
+  usePostMonthlyDataMutation,
+  useGetAnalyticsQuery,
+  useGetReportsQuery,
+} = api

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,95 @@
+export const AUTH_BASE_URL = process.env.VITE_AUTH_BASE_URL || ''
+export const CLIENT_ID = process.env.VITE_AUTH_CLIENT_ID || ''
+export const REDIRECT_URI = process.env.VITE_AUTH_REDIRECT_URI || window.location.origin
+export const SCOPE = process.env.VITE_AUTH_SCOPE || ''
+
+const CODE_VERIFIER_KEY = 'pkce_code_verifier'
+
+function base64UrlEncode(buffer: ArrayBuffer | Uint8Array) {
+  const bytes = new Uint8Array(buffer)
+  let str = ''
+  for (let i = 0; i < bytes.byteLength; i++) {
+    str += String.fromCharCode(bytes[i])
+  }
+  return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function generateCodeVerifier(): string {
+  const array = new Uint8Array(32)
+  crypto.getRandomValues(array)
+  return base64UrlEncode(array)
+}
+
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier)
+  const digest = await crypto.subtle.digest('SHA-256', data)
+  return base64UrlEncode(digest)
+}
+
+export async function login() {
+  const verifier = generateCodeVerifier()
+  sessionStorage.setItem(CODE_VERIFIER_KEY, verifier)
+  const challenge = await generateCodeChallenge(verifier)
+
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT_URI,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+    scope: SCOPE,
+  })
+
+  window.location.assign(`${AUTH_BASE_URL}/authorize?${params.toString()}`)
+}
+
+export async function handleRedirectCallback() {
+  const params = new URLSearchParams(window.location.search)
+  const code = params.get('code')
+  const verifier = sessionStorage.getItem(CODE_VERIFIER_KEY)
+  if (!code || !verifier) {
+    return
+  }
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: CLIENT_ID,
+    code,
+    redirect_uri: REDIRECT_URI,
+    code_verifier: verifier,
+  })
+
+  await fetch(`${AUTH_BASE_URL}/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+    credentials: 'include',
+  })
+
+  sessionStorage.removeItem(CODE_VERIFIER_KEY)
+  window.history.replaceState(null, '', window.location.pathname)
+}
+
+export async function refreshToken() {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: CLIENT_ID,
+  })
+  await fetch(`${AUTH_BASE_URL}/token`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body,
+    credentials: 'include',
+  })
+}
+
+export async function logout() {
+  await fetch(`${AUTH_BASE_URL}/logout`, {
+    method: 'POST',
+    credentials: 'include',
+  })
+}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,17 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import { api } from '../services/api'
+
+export const store = configureStore({
+  reducer: {
+    [api.reducerPath]: api.reducer,
+  },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(api.middleware),
+})
+
+export type AppDispatch = typeof store.dispatch
+export type RootState = ReturnType<typeof store.getState>
+
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector


### PR DESCRIPTION
## Summary
- implement `authService` with PKCE helpers
- add functions for login, redirect handling, token refresh and logout

## Testing
- no tests run per instructions

------
https://chatgpt.com/codex/tasks/task_e_687fd80ecc6c8332a3411cc6f466d31f